### PR TITLE
Updated for Filament Run-out switch

### DIFF
--- a/Marlin/pins_ULTIMAIN_2.h
+++ b/Marlin/pins_ULTIMAIN_2.h
@@ -95,7 +95,7 @@
 #define SAFETY_TRIGGERED_PIN     28 // PIN to detect the safety circuit has triggered
 #define MAIN_VOLTAGE_MEASURE_PIN 14 // ANALOG PIN to measure the main voltage, with a 100k - 4k7 resitor divider.
 #define FIL_RUNOUT_PIN    69        // Filament Runout sensor.  NC switch with internal pull up resistors.
-				    // This is the "Analog J9" on the Wanhao/Ultiboard_2 main board.
+				    // This is the connector "Analog J9" on the Wanhao/Ultiboard_2 main board.
 
 //
 // LCD / Controller

--- a/Marlin/pins_ULTIMAIN_2.h
+++ b/Marlin/pins_ULTIMAIN_2.h
@@ -94,6 +94,8 @@
 #define LED_PIN             8
 #define SAFETY_TRIGGERED_PIN     28 // PIN to detect the safety circuit has triggered
 #define MAIN_VOLTAGE_MEASURE_PIN 14 // ANALOG PIN to measure the main voltage, with a 100k - 4k7 resitor divider.
+#define FIL_RUNOUT_PIN    69        // Filament Runout sensor.  NC switch with internal pull up resistors.
+				    // This is the "Analog J9" on the Wanhao/Ultiboard_2 main board.
 
 //
 // LCD / Controller


### PR DESCRIPTION
Add a pin definition for for the "Analog J19" connector to be used as a Filament Run-Out detector switch.