### PR TITLE
Check filament runout when printing over USB & SD

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9911,7 +9911,7 @@ void disable_all_steppers() {
 void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
 
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-    if ((IS_SD_PRINTING || print_job_timer.isRunning()) && (READ(FIL_RUNOUT_PIN) == FIL_RUNOUT_INVERTING))
+    if ((print_job_timer.isRunning()) && (READ(FIL_RUNOUT_PIN) == FIL_RUNOUT_INVERTING)) //allow filament runout when printing over USB and SD_Card
       handle_filament_runout();
   #endif
 


### PR DESCRIPTION
allow filament runout checks when printing over USB and SD_Card by removing IS_SD_PRINTING check. (line 9914)