### PR TITLE
Update Configuration.h

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -500,7 +500,7 @@
  * Override with M92
  *                                      X, Y, Z, E0 [, E1[, E2[, E3]]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80.0395, 80.0395, 400.48, 99.1 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80.0395, 80.0395, 400.48, 94.3 }
 
 /**
  * Default Max Feed Rate (mm/s)


### PR DESCRIPTION
Current extruder step default setting (99.1) is different from Wanhao's default setting (94.3).  Reverted to Wanhao's setting of 94.3